### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.writing.txt
+++ b/LICENSE.writing.txt
@@ -1,1 +1,1 @@
-Except where otherwise noted, this work is licensed under http://creativecommons.org/licenses/by-nd/3.0/
+Except where otherwise noted, this work is licensed under https://creativecommons.org/licenses/by-nd/3.0/

--- a/README.adoc
+++ b/README.adoc
@@ -2,7 +2,7 @@
 :icons: font
 :source-highlighter: prettify
 :project_id: gs-accessing-data-neo4j
-This guide walks you through the process of using http://projects.spring.io/spring-data-neo4j/[Spring Data Neo4j] to build an application that stores data in and retrieves it from http://www.neo4j.com/[Neo4j], a graph-based database.
+This guide walks you through the process of using https://projects.spring.io/spring-data-neo4j/[Spring Data Neo4j] to build an application that stores data in and retrieves it from https://www.neo4j.com/[Neo4j], a graph-based database.
 
 
 == What you'll build
@@ -109,7 +109,7 @@ include::complete/src/main/resources/application.properties[]
 
 This includes the default username `neo4j` and the newly set password `secret` we picked earlier.
 
-WARNING: Do NOT store real credentials in your source repository. Instead, configure them in your runtime using http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-external-config[Spring Boot's property overrides].
+WARNING: Do NOT store real credentials in your source repository. Instead, configure them in your runtime using https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-external-config[Spring Boot's property overrides].
 
 With this in place, let's wire this up and see what it looks like!
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://creativecommons.org/licenses/by-nd/3.0/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/by-nd/3.0/ ([https](https://creativecommons.org/licenses/by-nd/3.0/) result 200).
* [ ] http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/ ([https](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/) result 200).
* [ ] http://projects.spring.io/spring-data-neo4j/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-data-neo4j/ ([https](https://projects.spring.io/spring-data-neo4j/) result 200).
* [ ] http://www.neo4j.com/ with 1 occurrences migrated to:  
  https://www.neo4j.com/ ([https](https://www.neo4j.com/) result 301).

# Ignored
These URLs were intentionally ignored.

* http://localhost:7474 with 1 occurrences
* http://localhost:7474/ with 1 occurrences